### PR TITLE
Fix off-by-one in round-script OP_ROLL positions and SIGHASH_SINGLE bug value

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,9 @@ These constraints force careful parameter tuning. The "bonus key" optimization a
 │   ├── secp256k1_fast.py    # Fast EC math using coincurve
 │   ├── benchmark.py         # Benchmarking and graduated tests
 │   ├── qsb_run.py          # vast.ai fleet orchestration (multi-machine)
-│   └── run_qsb.sh          # All-in-one run script for vast.ai
+│   ├── run_qsb.sh          # All-in-one run script for vast.ai
+│   ├── test_consensus_cpu.py     # Pure-Python consensus gate (real ECDSA)
+│   └── test_bitcoinconsensus.py  # Gold-standard gate via libbitcoinconsensus
 ├── script/                  # Full generated Bitcoin Scripts
 ├── v16/                     # Current orchestrator — start here to run a search
 │   ├── qsb_orchestrator_v16.py  # Rents hosts, uploads bundle, drives the search

--- a/config_a/pipeline/bitcoin_tx.py
+++ b/config_a/pipeline/bitcoin_tx.py
@@ -161,8 +161,13 @@ class Transaction:
             pass  # no outputs
         elif base == 0x03:  # SIGHASH_SINGLE
             if input_index >= len(self.outputs):
-                # SIGHASH_SINGLE bug: return 1
-                return 1
+                # SIGHASH_SINGLE bug. Bitcoin Core returns uint256::ONE, whose
+                # raw little-endian bytes (01 00 .. 00) are fed to secp256k1's
+                # msg32 and read BIG-ENDIAN — i.e. the message scalar is 2**248,
+                # NOT the integer 1. Using 1 here makes every dummy pubkey be
+                # recovered against the wrong message and fail under real Bitcoin
+                # Core consensus (confirmed via libbitcoinconsensus).
+                return 1 << 248
             for i in range(input_index + 1):
                 if i < input_index:
                     tx_copy.add_output(TxOut(-1, b''))
@@ -331,6 +336,51 @@ def _encode_9byte_sig(r, s, sighash=0x03):
 
 
 # ============================================================
+# Stack model — computes OP_ROLL positions from the ACTUAL modeled stack
+# instead of hand-derived formulas. The original build_round_script formulas
+# were off by one (they omitted the OP_0 CHECKMULTISIG dummy and used a fixed
+# commitment gap n+1 that must actually shrink to n+1-i per iteration) and did
+# not account for cross-round drift (round 2 sits one item higher than round 1
+# because round 1 leaves a CHECKMULTISIG result on the stack). Threading this
+# model through the whole script makes every position correct by construction.
+# ============================================================
+
+class _StackModel:
+    """Models the script stack (index -1 = top). Tokens are opaque labels."""
+    def __init__(self):
+        self.s = []                       # bottom .. top
+
+    def push(self, tok):
+        self.s.append(tok)
+
+    def depth(self, tok):
+        """0 = top."""
+        for k in range(len(self.s) - 1, -1, -1):
+            if self.s[k] == tok:
+                return len(self.s) - 1 - k
+        raise KeyError(tok)
+
+    def deepest_dummy(self, rnd):
+        """Depth of the deepest remaining dummy of round `rnd` (for OP_MIN sanitize)."""
+        best = -1
+        for k in range(len(self.s)):
+            t = self.s[k]
+            if isinstance(t, tuple) and len(t) == 3 and t[0] == 'D' and t[1] == rnd:
+                best = max(best, len(self.s) - 1 - k)
+        return best
+
+    def roll(self, d):
+        """OP_ROLL semantics (the count has already been popped): move the item
+        at depth d to the top."""
+        i = len(self.s) - 1 - d
+        self.s.append(self.s.pop(i))
+
+    def pop(self, k=1):
+        for _ in range(k):
+            self.s.pop()
+
+
+# ============================================================
 # QSB Script Builder
 # ============================================================
 
@@ -465,8 +515,130 @@ class QSBScriptBuilder:
             script += bytes([OP_CHECKSIGVERIFY]) # 5: verify (sig_puzzle, key_puzzle)
         return script
 
+    # ---- round parameter helpers (corrected stack-model path) ----
+    def _round_t(self, round_idx):
+        t_signed = self.t1_signed if round_idx == 0 else self.t2_signed
+        t_bonus = self.t1_bonus if round_idx == 0 else self.t2_bonus
+        return t_signed, t_bonus, t_signed + t_bonus
+
+    def _canonical_subset(self, round_idx):
+        """Any valid t_total distinct pool indices; used to build the
+        (subset-independent) locking script."""
+        _, _, t_total = self._round_t(round_idx)
+        return list(range(t_total))
+
+    def _seed_witness(self, m, round_idx):
+        """Push this round's witness tokens (bottom..top): kp, kn, pubs, pres, idxs.
+        Matches cmd_assemble's witness order."""
+        t_signed, _, t_total = self._round_t(round_idx)
+        R = round_idx
+        m.push(('kp', R)); m.push(('kn', R))
+        for j in range(t_total - 1, -1, -1): m.push(('pub', R, j))
+        for j in range(t_signed - 1, -1, -1): m.push(('pre', R, j))
+        for j in range(t_total - 1, -1, -1): m.push(('idx', R, j))
+
+    def _model_pinning(self, m):
+        """Model the pinning stage's net stack effect: it consumes key_puzzle and
+        key_nonce (the pinning witness) and leaves nothing."""
+        m.pop(2)
+
+    def _emit_round(self, m, round_idx, sig_nonce_bytes, subset):
+        """Emit one round's script bytes for a SINGLE-HASH puzzle (ripemd160 or
+        sha256), computing every OP_ROLL position from the live stack model `m`
+        (which must already hold this round's witness block and everything below
+        it). Returns (script_bytes, idxvals) where idxvals are the per-selection
+        witness index numbers for `subset`."""
+        if self.hash_mode not in ('ripemd160', 'sha256'):
+            raise ValueError("_emit_round supports single-hash modes only; "
+                             "hash_mode=%r uses the legacy path" % self.hash_mode)
+        hashop = OP_RIPEMD160_OP if self.hash_mode == 'ripemd160' else OP_SHA256_OP
+        n = self.n
+        R = round_idx
+        t_signed, t_bonus, t_total = self._round_t(round_idx)
+        out = bytearray()
+        # --- round data pushes ---
+        for p in range(n - 1, -1, -1):
+            out += push_data(self.hors_commitments[R][p]); m.push(('C', R, p))
+        for p in range(n - 1, -1, -1):
+            out += push_data(self.dummy_sigs[R][p]); m.push(('D', R, p))
+        out += bytes([OP_0]); m.push(('zero', R))
+        out += push_data(sig_nonce_bytes); m.push(('signonce', R))
+        idxvals = []
+        # --- signed selections (9 opcodes each) ---
+        for i in range(t_signed):
+            tgt = subset[i]
+            A = m.depth(('idx', R, i)); m.roll(A); m.pop(1); m.push(('iv', R, i))
+            san = m.deepest_dummy(R)
+            m.push(('iv', R, i))                                  # OP_DUP
+            m.pop(1); dc = m.depth(('C', R, tgt)); m.roll(dc)     # OP_ADD + OP_ROLL (commitment)
+            D = m.depth(('pre', R, i)); m.roll(D)                 # preimage fetch
+            m.pop(2)                                              # OP_HASH160 + OP_EQUALVERIFY
+            m.pop(1); dd = m.depth(('D', R, tgt)); m.roll(dd)     # OP_ROLL (dummy)
+            gap = dc - dd; idxvals.append(dd)
+            out += push_number(A) + bytes([OP_ROLL])
+            out += push_number(san) + bytes([OP_MIN])
+            out += bytes([OP_DUP])
+            out += push_number(gap) + bytes([OP_ADD, OP_ROLL])
+            out += push_number(D) + bytes([OP_ROLL])
+            out += bytes([OP_HASH160, OP_EQUALVERIFY, OP_ROLL])
+        # --- bonus selections (3 opcodes each) ---
+        for bi in range(t_bonus):
+            j = t_signed + bi; tgt = subset[j]
+            A = m.depth(('idx', R, j)); m.roll(A); m.pop(1); m.push(('iv', R, j))
+            san = m.deepest_dummy(R)
+            m.pop(1); dd = m.depth(('D', R, tgt)); m.roll(dd); idxvals.append(dd)
+            out += push_number(A) + bytes([OP_ROLL])
+            out += push_number(san) + bytes([OP_MIN])
+            out += bytes([OP_ROLL])
+        # --- puzzle: ROLL key_nonce, DUP, HASH, ROLL key_puzzle, CHECKSIGVERIFY ---
+        pk = m.depth(('kn', R)); m.roll(pk); m.push(('kn', R)); m.pop(1); m.push(('sp', R))
+        pp = m.depth(('kp', R)); m.roll(pp); m.pop(2)
+        out += push_number(pk) + bytes([OP_ROLL, OP_DUP, hashop])
+        out += push_number(pp) + bytes([OP_ROLL, OP_CHECKSIGVERIFY])
+        # --- CHECKMULTISIG (t+1)-of-(t+1): pubkeys = t_total dummy pubs + key_nonce,
+        #     rolled so their order matches the gathered dummy-sig order. ---
+        mval = t_total + 1
+        out += push_number(mval); m.push(('M', R))
+        for tok in [('kn', R)] + [('pub', R, j) for j in range(t_total)]:
+            d = m.depth(tok); m.roll(d); out += push_number(d) + bytes([OP_ROLL])
+        out += push_number(mval); m.push(('N', R))
+        out += bytes([OP_CHECKMULTISIG])
+        # CHECKMULTISIG pops: N-value + N pubkeys + M-value + M sigs + dummy
+        m.pop(2 * (t_total + 1) + 3); m.push(('cms', R))
+        return bytes(out), idxvals
+
+    def compute_witness_indices(self, subsets):
+        """Given the chosen subsets {0:[...], 1:[...]}, return the model-derived
+        witness index numbers {0:[...], 1:[...]} the corrected selection loop
+        expects. Replays the same model build_full_script uses. Single-hash only."""
+        m = _StackModel()
+        self._seed_witness(m, 1)
+        self._seed_witness(m, 0)
+        m.push(('pin_kp',)); m.push(('pin_kn',))
+        self._model_pinning(m)
+        _, iv0 = self._emit_round(m, 0, b'\x30\x06\x02\x01\x01\x02\x01\x01\x01', subsets[0])
+        _, iv1 = self._emit_round(m, 1, b'\x30\x06\x02\x01\x01\x02\x01\x01\x01', subsets[1])
+        return {0: iv0, 1: iv1}
+
     def build_round_script(self, round_idx, sig_nonce_bytes):
-        """Build a single round's script"""
+        """Build a single round's script. Single-hash modes use the corrected
+        stack model IN ISOLATION (fresh stack); sha256_double uses the legacy
+        path. For a consensus-valid two-round lock use build_full_script, which
+        threads a shared model so round 2's positions account for round 1."""
+        if self.hash_mode in ('ripemd160', 'sha256'):
+            m = _StackModel()
+            self._seed_witness(m, round_idx)
+            script, _ = self._emit_round(m, round_idx, sig_nonce_bytes,
+                                         self._canonical_subset(round_idx))
+            return script
+        return self._build_round_script_legacy(round_idx, sig_nonce_bytes)
+
+    def _build_round_script_legacy(self, round_idx, sig_nonce_bytes):
+        """LEGACY hand-formula round builder. Retained ONLY for hash_mode
+        'sha256_double' (Config D), which is over-budget/deprecated and NOT
+        consensus-corrected — its selection positions still carry the original
+        off-by-one. Single-hash modes go through the corrected stack model
+        (_emit_round). Kept so verify_script_budget can still size Config D."""
         t_signed = self.t1_signed if round_idx == 0 else self.t2_signed
         t_bonus = self.t1_bonus if round_idx == 0 else self.t2_bonus
         t_total = t_signed + t_bonus
@@ -575,7 +747,21 @@ class QSBScriptBuilder:
         return script
     
     def build_full_script(self, pin_sig, round1_sig, round2_sig):
-        """Build the complete locking script"""
+        """Build the complete locking script. Single-hash modes thread a shared
+        stack model so round 2's OP_ROLL positions account for round 1's leftover
+        CHECKMULTISIG result (the cross-round drift the legacy path missed)."""
+        if self.hash_mode in ('ripemd160', 'sha256'):
+            m = _StackModel()
+            # full witness (bottom..top): round-2 block, round-1 block, pin kp, kn
+            self._seed_witness(m, 1)
+            self._seed_witness(m, 0)
+            m.push(('pin_kp',)); m.push(('pin_kn',))
+            script = bytearray(self.build_pinning_script(pin_sig))
+            self._model_pinning(m)
+            s0, _ = self._emit_round(m, 0, round1_sig, self._canonical_subset(0))
+            s1, _ = self._emit_round(m, 1, round2_sig, self._canonical_subset(1))
+            return bytes(script) + s0 + s1
+        # sha256_double: legacy concatenation (not consensus-corrected)
         script = self.build_pinning_script(pin_sig)
         script += self.build_round_script(0, round1_sig)
         script += self.build_round_script(1, round2_sig)

--- a/config_a/pipeline/qsb_pipeline.py
+++ b/config_a/pipeline/qsb_pipeline.py
@@ -873,7 +873,19 @@ def cmd_assemble(args):
     assert len(r2_indices) == t2, f"Expected {t2} round2 indices, got {len(r2_indices)}"
     
     full_script = h2b(state['full_script_hex'])
-    
+
+    # Corrected witness index encoding (single-hash modes): the selection loop
+    # reads model-derived dummy-depths, NOT raw pool indices. Rebuild a builder
+    # holding the pool data and compute the indices exactly as build_full_script
+    # positioned them. sha256_double keeps the legacy raw-index behaviour.
+    witness_indices = None
+    if hash_mode in ('ripemd160', 'sha256'):
+        _wb = QSBScriptBuilder(n, state['t1s'], state['t1b'], state['t2s'],
+                               state['t2b'], hash_mode=hash_mode)
+        _wb.hors_commitments = [[h2b(c) for c in state['hors_commitments'][r]] for r in range(2)]
+        _wb.dummy_sigs = [[h2b(s) for s in state['dummy_sigs'][r]] for r in range(2)]
+        witness_indices = _wb.compute_witness_indices({0: r1_indices, 1: r2_indices})
+
     print(f"  Locktime: {locktime}")
     print(f"  Sequence: {sequence} (0x{sequence:08X})")
     print(f"  Round 1 indices: {r1_indices}")
@@ -1060,7 +1072,10 @@ def cmd_assemble(args):
             print(f"    ERROR: round {ri+1} key_puzzle recovery failed!")
             return
         
-        # Recover dummy pubkeys (z=1)
+        # Recover dummy pubkeys via the SIGHASH_SINGLE bug. Bitcoin Core's bug
+        # value is 2**248 (uint256::ONE's little-endian bytes read big-endian by
+        # secp256k1), NOT the integer 1 — must match or the dummies fail consensus.
+        SIGHASH_SINGLE_BUG_Z = 1 << 248
         dummy_pubkeys = []
         for idx in indices:
             ds_bytes = h2b(state['dummy_sigs'][ri][idx])
@@ -1070,7 +1085,7 @@ def cmd_assemble(args):
                 return
             recovered = None
             for flag in [0, 1]:
-                pt = ecdsa_recover(dr, ds_val, 1, flag)
+                pt = ecdsa_recover(dr, ds_val, SIGHASH_SINGLE_BUG_Z, flag)
                 if pt:
                     recovered = compress_pubkey(pt)
                     break
@@ -1078,7 +1093,7 @@ def cmd_assemble(args):
                 from secp256k1 import N as _CURVE_N, P as _CURVE_P
                 if dr + _CURVE_N < _CURVE_P:
                     for flag in [0, 1]:
-                        pt = ecdsa_recover(dr + _CURVE_N, ds_val, 1, flag)
+                        pt = ecdsa_recover(dr + _CURVE_N, ds_val, SIGHASH_SINGLE_BUG_Z, flag)
                         if pt:
                             recovered = compress_pubkey(pt)
                             break
@@ -1114,8 +1129,15 @@ def cmd_assemble(args):
             witness += push_data(pub)
         for pre in reversed(rr['preimages']):
             witness += push_data(pre)
-        for idx in reversed(rr['subset']):
-            witness += push_number(idx)
+        if witness_indices is not None:
+            # model-derived index numbers (NOT raw pool indices); pushed so that
+            # selection 0's index ends on top, matching _seed_witness order.
+            ivs = witness_indices[rd]
+            for j in range(len(ivs) - 1, -1, -1):
+                witness += push_number(ivs[j])
+        else:
+            for idx in reversed(rr['subset']):
+                witness += push_number(idx)
     
     witness += push_data(key_puzzle_pin)
     witness += push_data(key_nonce_pin)

--- a/config_a/verify/test_consensus_core.py
+++ b/config_a/verify/test_consensus_core.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""
+Gold-standard consensus gate for the config_a builder.
+
+Builds the config_a lock and runs it through REAL Bitcoin Core consensus code
+(libbitcoinconsensus, via ../../QSB/qsb_verify). The puzzle CHECKSIGVERIFYs are
+relaxed to OP_2DROP (identical opcode count + stack effect) because the ~2^46
+hash-to-DER puzzle is unsolved here; the pinning bind and BOTH CHECKMULTISIGs
+plus every HORS EQUALVERIFY stay REAL, so the off-by-one selection logic and the
+SIGHASH_SINGLE-bug dummy recovery are exercised for real.
+
+Modes:
+  --witness legacy : replicate config_a/pipeline/qsb_pipeline.cmd_assemble exactly
+                     (raw pool indices, dummy pubkeys recovered with z=1).
+  --witness fixed  : model-derived indices + dummy pubkeys recovered with z=2**248.
+
+Config Ar = ripemd160 puzzle, Config A = sha256 puzzle (both single-hash).
+"""
+import sys, struct, hashlib, subprocess, tempfile, os, argparse
+from pathlib import Path
+ROOT = Path(__file__).resolve().parent.parent          # config_a/
+sys.path.insert(0, str(ROOT / "pipeline"))
+
+# ── pure-python RIPEMD160 (OpenSSL3 dropped it) ──
+def _rol(x,n): return ((x<<n)|(x>>(32-n)))&0xFFFFFFFF
+_K1=(0,0x5A827999,0x6ED9EBA1,0x8F1BBCDC,0xA953FD4E);_K2=(0x50A28BE6,0x5C4DD124,0x6D703EF3,0x7A6D76E9,0)
+_R1=[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,7,4,13,1,10,6,15,3,12,0,9,5,2,14,11,8,3,10,14,4,9,15,8,1,2,7,0,6,13,11,5,12,1,9,11,10,0,8,12,4,13,3,7,15,14,5,6,2,4,0,5,9,7,12,2,10,14,1,3,8,11,6,15,13]
+_R2=[5,14,7,0,9,2,11,4,13,6,15,8,1,10,3,12,6,11,3,7,0,13,5,10,14,15,8,12,4,9,1,2,15,5,1,3,7,14,6,9,11,8,12,2,10,0,4,13,8,6,4,1,3,11,15,0,5,12,2,13,9,7,10,14,12,15,10,4,1,5,8,7,6,2,13,14,0,3,9,11]
+_S1=[11,14,15,12,5,8,7,9,11,13,14,15,6,7,9,8,7,6,8,13,11,9,7,15,7,12,15,9,11,7,13,12,11,13,6,7,14,9,13,15,14,8,13,6,5,12,7,5,11,12,14,15,14,15,9,8,9,14,5,6,8,6,5,12,9,15,5,11,6,8,13,12,5,12,13,14,11,8,5,6]
+_S2=[8,9,9,11,13,15,15,5,7,7,8,11,14,14,12,6,9,13,15,7,12,8,9,11,7,7,12,7,6,15,13,11,9,7,15,11,8,6,6,14,12,13,5,14,13,13,7,5,15,5,8,11,14,14,6,14,6,9,12,9,12,5,15,8,8,5,12,9,12,5,14,6,8,13,6,5,15,13,11,11]
+def _f(j,x,y,z):
+    if j<16:return x^y^z
+    if j<32:return (x&y)|(~x&z)
+    if j<48:return (x|~y)^z
+    if j<64:return (x&z)|(y&~z)
+    return x^(y|~z)
+def ripemd160(data):
+    h=[0x67452301,0xEFCDAB89,0x98BADCFE,0x10325476,0xC3D2E1F0];msg=bytearray(data);ml=len(data)*8;msg.append(0x80)
+    while len(msg)%64!=56:msg.append(0)
+    msg+=struct.pack('<Q',ml)
+    for off in range(0,len(msg),64):
+        X=struct.unpack_from('<16I',msg,off);a,b,c,d,e=h;A,B,C,D,E=h
+        for j in range(80):
+            T=(a+_f(j,b,c,d)+X[_R1[j]]+_K1[j//16])&0xFFFFFFFF;T=(_rol(T,_S1[j])+e)&0xFFFFFFFF;a,e,d,c,b=e,d,_rol(c,10),b,T
+            T=(A+_f(79-j,B,C,D)+X[_R2[j]]+_K2[j//16])&0xFFFFFFFF;T=(_rol(T,_S2[j])+E)&0xFFFFFFFF;A,E,D,C,B=E,D,_rol(C,10),B,T
+        T=(h[1]+c+D)&0xFFFFFFFF;h[1]=(h[2]+d+E)&0xFFFFFFFF;h[2]=(h[3]+e+A)&0xFFFFFFFF;h[3]=(h[4]+a+B)&0xFFFFFFFF;h[4]=(h[0]+b+C)&0xFFFFFFFF;h[0]=T
+    return struct.pack('<5I',*h)
+
+import secp256k1 as S
+S.ripemd160=ripemd160; S.hash160=lambda d: ripemd160(hashlib.sha256(d).digest())
+import bitcoin_tx as bt
+bt.ripemd160=ripemd160; bt.hash160=S.hash160
+from bitcoin_tx import (QSBScriptBuilder, Transaction, TxIn, TxOut,
+                        find_and_delete, push_data, push_number, _valid_small_r_values)
+from secp256k1 import N, P, ecdsa_recover, ecdsa_verify, compress_pubkey, encode_der_sig
+
+QV = "/home/tomer/workspace/QSB/qsb_verify/target/release/qsb_verify"
+
+def parse_der(sig):
+    if len(sig)<9 or sig[0]!=0x30: return None
+    if sig[1]+3!=len(sig): return None
+    i=2
+    if sig[i]!=0x02: return None
+    i+=1; rl=sig[i]; i+=1
+    if rl==0 or i+rl>len(sig)-1 or sig[i]&0x80: return None
+    if rl>1 and sig[i]==0 and not (sig[i+1]&0x80): return None
+    r=int.from_bytes(sig[i:i+rl],'big'); i+=rl
+    if sig[i]!=0x02: return None
+    i+=1; sl=sig[i]; i+=1
+    if sl==0 or i+sl!=len(sig)-1: return None
+    return (r, int.from_bytes(sig[i:i+sl],'big'), sig[-1])
+
+def recover_key(r,s,z):
+    for rr in ([r]+([r+N] if r+N<P else [])):
+        for rec in (0,1):
+            pt=ecdsa_recover(rr,s,z,rec)
+            if pt and ecdsa_verify(pt,z,r,s): return compress_pubkey(pt)
+    return None
+
+def relax(script):
+    """Turn every puzzle CHECKSIGVERIFY (all but the 1st = pinning bind) into OP_2DROP."""
+    out=bytearray(script); i=0; seen=0
+    while i<len(out):
+        op=out[i]
+        if op==0: i+=1
+        elif 1<=op<=75: i+=1+op
+        elif op==0x4c: i+=2+out[i+1]
+        elif op==0x4d: i+=3+(out[i+1]|out[i+2]<<8)
+        else:
+            if op==0xad:
+                seen+=1
+                if seen>=2: out[i]=0x6d      # OP_2DROP
+            i+=1
+    return bytes(out)
+
+def run(config_name, cfg, witness_mode):
+    b=QSBScriptBuilder(cfg['n'],cfg['t1s'],cfg['t1b'],cfg['t2s'],cfg['t2b'],hash_mode=cfg['hash_mode'])
+    b.generate_keys()
+    vr=_valid_small_r_values()[0]
+    pin_sig=encode_der_sig(vr,1,0x01); sig_nonce=[encode_der_sig(vr,2,0x01), encode_der_sig(vr,3,0x01)]
+    lock=b.build_full_script(pin_sig, sig_nonce[0], sig_nonce[1])
+    lock_relaxed=relax(lock)
+
+    QSB=1
+    tx=Transaction(version=1, locktime=1234567)
+    tx.add_input(TxIn(b'\x00'*32,0,b'',0xfffffffe))
+    tx.add_input(TxIn(b'\x11'*32,0,b'',0x80000000))
+    tx.add_output(TxOut(90000, bytes([0x00,0x14])+b'\x22'*20))
+    t1=cfg['t1s']+cfg['t1b']; t2=cfg['t2s']+cfg['t2b']
+    subs={0: sorted([3,17,42,66,88,101,119,140][:cfg['t1s']])+[9,29,49][:cfg['t1b']],
+          1: sorted([5,20,55,70,90,110,130][:cfg['t2s']])+[15,45,75][:cfg['t2b']]}
+    subs={0: subs[0][:t1], 1: subs[1][:t2]}
+
+    z_for_dummy = 1 if witness_mode=='legacy' else (1<<248)
+    if witness_mode=='fixed':
+        iv=b.compute_witness_indices(subs)
+    else:
+        iv={0: list(reversed(subs[0]))[::-1], 1: list(reversed(subs[1]))[::-1]}  # raw indices
+
+    def round_keys(R):
+        sc=find_and_delete(lock_relaxed, sig_nonce[R])
+        for i in subs[R]: sc=find_and_delete(sc, b.dummy_sigs[R][i])
+        z=tx.sighash(QSB, sc, 0x01)
+        pr,ps,_=parse_der(sig_nonce[R]); kn=recover_key(pr,ps,z)
+        dp=[recover_key(*parse_der(b.dummy_sigs[R][i])[:2], z_for_dummy) for i in subs[R]]
+        return kn,dp
+
+    wit=b''
+    for R in (1,0):
+        ts=cfg['t1s'] if R==0 else cfg['t2s']
+        kn,dp=round_keys(R)
+        if not (kn and all(dp)): return (config_name, witness_mode, False, f"recover round {R}")
+        wit+=push_data(b'\x02'+b'\x00'*32)+push_data(kn)
+        for p in reversed(dp): wit+=push_data(p)
+        for j in range(ts-1,-1,-1): wit+=push_data(b.hors_secrets[R][subs[R][j]])
+        if witness_mode=='fixed':
+            for j in range(len(iv[R])-1,-1,-1): wit+=push_number(iv[R][j])
+        else:
+            for idx in reversed(subs[R]): wit+=push_number(idx)
+    psc=find_and_delete(lock_relaxed, pin_sig); zp=tx.sighash(QSB,psc,0x01)
+    ppr,pps,_=parse_der(pin_sig); knp=recover_key(ppr,pps,zp)
+    if not knp: return (config_name, witness_mode, False, "pin recover")
+    wit+=push_data(b'\x02'+b'\x00'*32)+push_data(knp)
+    tx.inputs[QSB].script_sig=wit
+
+    ftx=Transaction(version=1, locktime=0)
+    ftx.add_input(TxIn(b'\x33'*32,0,b'',0xffffffff))
+    ftx.add_output(TxOut(100000, lock_relaxed))
+
+    d=tempfile.mkdtemp()
+    sp=os.path.join(d,'spend.hex'); fp=os.path.join(d,'fund.hex')
+    open(sp,'w').write(tx.serialize().hex()); open(fp,'w').write(ftx.serialize().hex())
+    r=subprocess.run([QV, sp, fp, "0", "1"], capture_output=True, text=True)
+    ok = any("ALL_PRE_TAPROOT" in ln and "✅ SUCCESS" in ln for ln in r.stdout.splitlines())
+    detail = "consensus-valid" if ok else "REJECTED by libbitcoinconsensus"
+    if os.environ.get("QSB_DEBUG"):
+        print("---- qsb_verify stdout ----"); print(r.stdout[-1200:]); print("---- stderr ----"); print(r.stderr[-400:])
+    return (config_name, witness_mode, ok, detail)
+
+CONFIGS = {
+    'Ar': {'n':150,'t1s':8,'t1b':1,'t2s':7,'t2b':2,'hash_mode':'ripemd160'},
+    'A' : {'n':150,'t1s':8,'t1b':1,'t2s':7,'t2b':2,'hash_mode':'sha256'},
+}
+
+def cfg_hm(c): return c['hash_mode']
+
+if __name__=='__main__':
+    ap=argparse.ArgumentParser()
+    ap.add_argument('--witness', choices=['legacy','fixed'], default='fixed')
+    ap.add_argument('--config', choices=list(CONFIGS)+['all'], default='all')
+    a=ap.parse_args()
+    names=list(CONFIGS) if a.config=='all' else [a.config]
+    print(f"witness mode: {a.witness}\n")
+    allok=True
+    for nm in names:
+        cn,wm,ok,det=run(nm, CONFIGS[nm], a.witness)
+        allok &= ok
+        print(f"  [{cn:2s} / {cfg_hm(CONFIGS[nm])}] {'✅' if ok else '❌'} {det}")
+    sys.exit(0 if allok else 1)

--- a/pipeline/bitcoin_tx.py
+++ b/pipeline/bitcoin_tx.py
@@ -457,6 +457,10 @@ class QSBScriptBuilder:
         the live stack model `m` (which must already hold this round's witness
         block and everything below it). Returns (script_bytes, idxvals) where
         idxvals are the per-selection witness index numbers for `subset`."""
+        if self.hash_mode not in ('ripemd160', 'sha256'):
+            raise ValueError("_emit_round supports single-hash modes only; "
+                             "hash_mode=%r is not consensus-corrected" % self.hash_mode)
+        hashop = OP_RIPEMD160_OP if self.hash_mode == 'ripemd160' else OP_SHA256_OP
         n = self.n
         R = round_idx
         t_signed, t_bonus, t_total = self._round_t(round_idx)
@@ -495,10 +499,10 @@ class QSBScriptBuilder:
             out += push_number(A) + bytes([OP_ROLL])
             out += push_number(san) + bytes([OP_MIN])
             out += bytes([OP_ROLL])
-        # --- puzzle: ROLL key_nonce, DUP, RIPEMD160, ROLL key_puzzle, CHECKSIGVERIFY ---
+        # --- puzzle: ROLL key_nonce, DUP, <hashop>, ROLL key_puzzle, CHECKSIGVERIFY ---
         pk = m.depth(('kn', R)); m.roll(pk); m.push(('kn', R)); m.pop(1); m.push(('sp', R))
         pp = m.depth(('kp', R)); m.roll(pp); m.pop(2)
-        out += push_number(pk) + bytes([OP_ROLL, OP_DUP, OP_RIPEMD160_OP])
+        out += push_number(pk) + bytes([OP_ROLL, OP_DUP, hashop])
         out += push_number(pp) + bytes([OP_ROLL, OP_CHECKSIGVERIFY])
         # --- CHECKMULTISIG (t+1)-of-(t+1): pubkeys = t_total dummy pubs + key_nonce,
         #     rolled so their order matches the gathered dummy-sig order. ---

--- a/pipeline/bitcoin_tx.py
+++ b/pipeline/bitcoin_tx.py
@@ -82,7 +82,7 @@ class TxIn:
         self.vout = vout
         self.script_sig = script_sig
         self.sequence = sequence
-    
+
     def serialize(self):
         return (
             self.txid +
@@ -96,7 +96,7 @@ class TxOut:
     def __init__(self, value, script_pubkey):
         self.value = value
         self.script_pubkey = script_pubkey
-    
+
     def serialize(self):
         return (
             struct.pack('<q', self.value) +
@@ -110,13 +110,13 @@ class Transaction:
         self.inputs = []
         self.outputs = []
         self.locktime = locktime
-    
+
     def add_input(self, txin):
         self.inputs.append(txin)
-    
+
     def add_output(self, txout):
         self.outputs.append(txout)
-    
+
     def serialize(self):
         result = struct.pack('<I', self.version)
         result += serialize_varint(len(self.inputs))
@@ -127,7 +127,7 @@ class Transaction:
             result += out.serialize()
         result += struct.pack('<I', self.locktime)
         return result
-    
+
     def sighash(self, input_index, script_code, sighash_type=0x01):
         """
         Compute legacy sighash for input at input_index.
@@ -135,34 +135,36 @@ class Transaction:
         """
         # Copy transaction
         tx_copy = Transaction(self.version, self.locktime)
-        
+
         for i, inp in enumerate(self.inputs):
             if i == input_index:
                 new_inp = TxIn(inp.txid, inp.vout, script_code, inp.sequence)
             else:
                 new_inp = TxIn(inp.txid, inp.vout, b'', inp.sequence)
-            
+
             # Handle SIGHASH_ANYONECANPAY
             if sighash_type & 0x80:
                 if i != input_index:
                     continue
-            
+
             # Handle SIGHASH_NONE / SIGHASH_SINGLE sequence
             base = sighash_type & 0x1f
             if base == 0x02 or base == 0x03:  # NONE or SINGLE
                 if i != input_index:
                     new_inp.sequence = 0
-            
+
             tx_copy.add_input(new_inp)
-        
+
         # Handle outputs
         base = sighash_type & 0x1f
         if base == 0x02:  # SIGHASH_NONE
             pass  # no outputs
         elif base == 0x03:  # SIGHASH_SINGLE
             if input_index >= len(self.outputs):
-                # SIGHASH_SINGLE bug: return 1
-                return 1
+                # SIGHASH_SINGLE bug. Bitcoin Core returns uint256::ONE, whose
+                # raw little-endian bytes (01 00 .. 00) are fed to secp256k1's
+                # msg32 and read BIG-ENDIAN — i.e. the message scalar is 2**248,
+                return 1 << 248
             for i in range(input_index + 1):
                 if i < input_index:
                     tx_copy.add_output(TxOut(-1, b''))
@@ -171,7 +173,7 @@ class Transaction:
         else:  # SIGHASH_ALL
             for out in self.outputs:
                 tx_copy.add_output(out)
-        
+
         serialized = tx_copy.serialize() + struct.pack('<I', sighash_type)
         return int.from_bytes(sha256d(serialized), 'big')
 
@@ -243,6 +245,52 @@ def _encode_9byte_sig(r, s, sighash=0x03):
 
 
 # ============================================================
+# Stack model — used to compute OP_ROLL positions from the ACTUAL modeled
+# stack instead of hand-derived formulas. The hand-derived formulas in the
+# original build_round_script were wrong (off-by-one: they counted sig_nonce
+# above the dummy block but forgot the OP_0 CHECKMULTISIG dummy, and used a
+# fixed commitment gap n+1 that must actually shrink to n+1-i per iteration).
+# Threading this model through the whole script makes every position correct
+# by construction and prevents cross-round drift (round 2 sits one item higher
+# than round 1 because round 1 leaves a CHECKMULTISIG result on the stack).
+# ============================================================
+
+class _StackModel:
+    """Models the script stack (index -1 = top). Tokens are opaque labels."""
+    def __init__(self):
+        self.s = []                       # bottom .. top
+
+    def push(self, tok):
+        self.s.append(tok)
+
+    def depth(self, tok):
+        """0 = top."""
+        for k in range(len(self.s) - 1, -1, -1):
+            if self.s[k] == tok:
+                return len(self.s) - 1 - k
+        raise KeyError(tok)
+
+    def deepest_dummy(self, rnd):
+        """Depth of the deepest remaining dummy of round `rnd` (for OP_MIN sanitize)."""
+        best = -1
+        for k in range(len(self.s)):
+            t = self.s[k]
+            if isinstance(t, tuple) and len(t) == 3 and t[0] == 'D' and t[1] == rnd:
+                best = max(best, len(self.s) - 1 - k)
+        return best
+
+    def roll(self, d):
+        """OP_ROLL semantics (the count has already been popped): move the item
+        at depth d to the top."""
+        i = len(self.s) - 1 - d
+        self.s.append(self.s.pop(i))
+
+    def pop(self, k=1):
+        for _ in range(k):
+            self.s.pop()
+
+
+# ============================================================
 # QSB Script Builder
 # ============================================================
 
@@ -260,23 +308,23 @@ class QSBScriptBuilder:
         # Generate HORS secrets and commitments
         self.hors_secrets = []  # [round][index] = 20 bytes
         self.hors_commitments = []  # [round][index] = 20 bytes
-        
+
         # Generate dummy sig data
         self.dummy_sigs = []  # [round][index] = 9 bytes
-        
+
         # Pinning sig (will be set)
         self.pin_sig_nonce = None
         self.pin_privkey = None
-        
+
         # Round sigs
         self.round_sig_nonce = []  # [round] = sig bytes
         self.round_privkeys = []  # [round] = privkey int
-        
+
     def generate_keys(self):
         """Generate all keys and commitments"""
         # Precompute valid small r values for 9-byte sigs
         small_r_values = _valid_small_r_values()
-        
+
         for r in range(2):
             # HORS
             secrets_r = []
@@ -288,7 +336,7 @@ class QSBScriptBuilder:
                 commits_r.append(commitment)
             self.hors_secrets.append(secrets_r)
             self.hors_commitments.append(commits_r)
-            
+
             # Dummy sigs: 9-byte minimum using SIGHASH_SINGLE bug (z=1)
             # Format: 30 06 02 01 <r> 02 01 <s> 03
             # r must be a valid x-coordinate on secp256k1 (1-127)
@@ -306,10 +354,10 @@ class QSBScriptBuilder:
                 assert sig not in dummy_sigs_r, f"Duplicate sig at round {r}, index {i}"
                 dummy_sigs_r.append(sig)
             self.dummy_sigs.append(dummy_sigs_r)
-        
+
         # Pinning key (not used for signing — just a placeholder)
         self.pin_privkey = int.from_bytes(os.urandom(32), 'big') % N
-        
+
         # Round keys (not used for signing)
         for r in range(2):
             privkey = int.from_bytes(os.urandom(32), 'big') % N
@@ -377,122 +425,130 @@ class QSBScriptBuilder:
             script += bytes([OP_CHECKSIGVERIFY]) # 5: verify (sig_puzzle, key_puzzle)
         return script
 
-    def build_round_script(self, round_idx, sig_nonce_bytes):
-        """Build a single round's script"""
+    # ---- round parameter helpers ----
+    def _round_t(self, round_idx):
         t_signed = self.t1_signed if round_idx == 0 else self.t2_signed
         t_bonus = self.t1_bonus if round_idx == 0 else self.t2_bonus
-        t_total = t_signed + t_bonus
-        
-        script = b''
-        
-        # Push n HORS commitments (reversed order)
-        for i in range(self.n - 1, -1, -1):
-            script += push_data(self.hors_commitments[round_idx][i])
-        
-        # Push n dummy sigs (reversed order)
-        for i in range(self.n - 1, -1, -1):
-            script += push_data(self.dummy_sigs[round_idx][i])
-        
-        # OP_0 (CHECKMULTISIG dummy)
-        script += bytes([OP_0])
-        
-        # sig_nonce (hardcoded, SIGHASH_ALL)
-        script += push_data(sig_nonce_bytes)
-        
-        # Signed selections (9 ops each)
+        return t_signed, t_bonus, t_signed + t_bonus
+
+    def _canonical_subset(self, round_idx):
+        """Any valid t_total distinct pool indices; used to build the
+        (subset-independent) locking script."""
+        _, _, t_total = self._round_t(round_idx)
+        return list(range(t_total))
+
+    def _seed_witness(self, m, round_idx):
+        """Push this round's witness tokens (bottom..top): kp, kn, pubs, pres, idxs.
+        Matches cmd_assemble's witness order."""
+        t_signed, _, t_total = self._round_t(round_idx)
+        R = round_idx
+        m.push(('kp', R)); m.push(('kn', R))
+        for j in range(t_total - 1, -1, -1): m.push(('pub', R, j))
+        for j in range(t_signed - 1, -1, -1): m.push(('pre', R, j))
+        for j in range(t_total - 1, -1, -1): m.push(('idx', R, j))
+
+    def _model_pinning(self, m):
+        """Model the pinning stage's net stack effect: it consumes key_puzzle and
+        key_nonce (the pinning witness) and leaves nothing."""
+        m.pop(2)
+
+    def _emit_round(self, m, round_idx, sig_nonce_bytes, subset):
+        """Emit one round's script bytes, computing every OP_ROLL position from
+        the live stack model `m` (which must already hold this round's witness
+        block and everything below it). Returns (script_bytes, idxvals) where
+        idxvals are the per-selection witness index numbers for `subset`."""
+        n = self.n
+        R = round_idx
+        t_signed, t_bonus, t_total = self._round_t(round_idx)
+        out = bytearray()
+        # --- round data pushes ---
+        for p in range(n - 1, -1, -1):
+            out += push_data(self.hors_commitments[R][p]); m.push(('C', R, p))
+        for p in range(n - 1, -1, -1):
+            out += push_data(self.dummy_sigs[R][p]); m.push(('D', R, p))
+        out += bytes([OP_0]); m.push(('zero', R))
+        out += push_data(sig_nonce_bytes); m.push(('signonce', R))
+        idxvals = []
+        # --- signed selections (9 opcodes each) ---
         for i in range(t_signed):
-            idx_pos = 2 * self.n + 1 - i
-            sanitize = self.n - i
-            preimage_pos = 2 * self.n + 1 + t_total - 2 * i
-            
-            script += push_number(idx_pos)
-            script += bytes([OP_ROLL])
-            script += push_number(sanitize)
-            script += bytes([OP_MIN])
-            script += bytes([OP_DUP])
-            script += push_number(self.n + 1)
-            script += bytes([OP_ADD])
-            script += bytes([OP_ROLL])
-            script += push_number(preimage_pos)
-            script += bytes([OP_ROLL])
-            script += bytes([OP_HASH160])
-            script += bytes([OP_EQUALVERIFY])
-            script += bytes([OP_ROLL])
-        
-        # Bonus selections (3 ops each)
-        for i in range(t_bonus):
-            j = t_signed + i
-            idx_pos = 2 * self.n + 1 - j
-            sanitize = self.n - j
-            
-            script += push_number(idx_pos)
-            script += bytes([OP_ROLL])
-            script += push_number(sanitize)
-            script += bytes([OP_MIN])
-            script += bytes([OP_ROLL])
-        
-        # Puzzle: ROLL key_nonce + DUP + SHA256 + CHECKSIGVERIFY
-        puzzle_pos = 2 * self.n + 2  # adjusted
-        
-        if self.hash_mode == 'sha256_double':
-            # Double hash mode: hash_choice is in witness adjacent to key_nonce
-            # After selection loop, hash_choice is at puzzle_pos, key_nonce at puzzle_pos+1
-            # ROLL hash_choice first, then key_nonce
-            script += push_number(puzzle_pos + 1)
-            script += bytes([OP_ROLL])             # get hash_choice
-            script += push_number(puzzle_pos + 1)
-            script += bytes([OP_ROLL])             # get key_nonce
-            script += bytes([OP_DUP])              # copy key_nonce for CHECKMULTISIG
-            # Stack: ... hash_choice key_nonce key_nonce_copy
-            # OP_ROT brings hash_choice to top
-            OP_ROT = 0x7b
-            script += bytes([OP_ROT])              # [kn, kn_copy, hash_choice]
-            script += bytes([OP_IF])
-            script += bytes([OP_SHA256_OP])         # pre-hash if bit=1
-            script += bytes([OP_ENDIF])
-            script += bytes([OP_SHA256_OP])         # always hash
-            # Adjust key_puzzle position (+1 for hash_choice witness element)
-            puzzle_key_pos = puzzle_pos + 1
-        else:
-            # Single hash mode (sha256 or ripemd160)
-            script += push_number(puzzle_pos)
-            script += bytes([OP_ROLL])
-            script += bytes([OP_DUP])
-            if self.hash_mode == 'ripemd160':
-                script += bytes([OP_RIPEMD160_OP])
-            else:
-                script += bytes([OP_SHA256_OP])
-            puzzle_key_pos = puzzle_pos
-        
-        # CHECKSIGVERIFY for sig_puzzle
-        script += push_number(puzzle_key_pos)
-        script += bytes([OP_ROLL])
-        script += bytes([OP_CHECKSIGVERIFY])
-        
-        # CHECKMULTISIG (t+1)-of-(t+1)
-        m = t_total + 1
-        script += push_number(m)
-        script += bytes([OP_2])
-        script += bytes([OP_ROLL])
-        
-        # Roll t dummy pubkeys
-        cms_roll_pos = 2 * self.n + 3 + (1 if self.hash_mode == 'sha256_double' else 0)
-        for j in range(t_total):
-            script += push_number(cms_roll_pos)
-            script += bytes([OP_ROLL])
-        
-        script += push_number(m)  # N = t+1
-        script += bytes([OP_CHECKMULTISIG])
-        
+            tgt = subset[i]
+            A = m.depth(('idx', R, i)); m.roll(A); m.pop(1); m.push(('iv', R, i))
+            san = m.deepest_dummy(R)
+            m.push(('iv', R, i))                                  # OP_DUP
+            m.pop(1); dc = m.depth(('C', R, tgt)); m.roll(dc)     # OP_ADD + OP_ROLL (commitment)
+            D = m.depth(('pre', R, i)); m.roll(D)                 # preimage fetch
+            m.pop(2)                                              # OP_HASH160 + OP_EQUALVERIFY
+            m.pop(1); dd = m.depth(('D', R, tgt)); m.roll(dd)     # OP_ROLL (dummy)
+            gap = dc - dd; idxvals.append(dd)
+            out += push_number(A) + bytes([OP_ROLL])
+            out += push_number(san) + bytes([OP_MIN])
+            out += bytes([OP_DUP])
+            out += push_number(gap) + bytes([OP_ADD, OP_ROLL])
+            out += push_number(D) + bytes([OP_ROLL])
+            out += bytes([OP_HASH160, OP_EQUALVERIFY, OP_ROLL])
+        # --- bonus selections (3 opcodes each) ---
+        for bi in range(t_bonus):
+            j = t_signed + bi; tgt = subset[j]
+            A = m.depth(('idx', R, j)); m.roll(A); m.pop(1); m.push(('iv', R, j))
+            san = m.deepest_dummy(R)
+            m.pop(1); dd = m.depth(('D', R, tgt)); m.roll(dd); idxvals.append(dd)
+            out += push_number(A) + bytes([OP_ROLL])
+            out += push_number(san) + bytes([OP_MIN])
+            out += bytes([OP_ROLL])
+        # --- puzzle: ROLL key_nonce, DUP, RIPEMD160, ROLL key_puzzle, CHECKSIGVERIFY ---
+        pk = m.depth(('kn', R)); m.roll(pk); m.push(('kn', R)); m.pop(1); m.push(('sp', R))
+        pp = m.depth(('kp', R)); m.roll(pp); m.pop(2)
+        out += push_number(pk) + bytes([OP_ROLL, OP_DUP, OP_RIPEMD160_OP])
+        out += push_number(pp) + bytes([OP_ROLL, OP_CHECKSIGVERIFY])
+        # --- CHECKMULTISIG (t+1)-of-(t+1): pubkeys = t_total dummy pubs + key_nonce,
+        #     rolled so their order matches the gathered dummy-sig order. ---
+        mval = t_total + 1
+        out += push_number(mval); m.push(('M', R))
+        for tok in [('kn', R)] + [('pub', R, j) for j in range(t_total)]:
+            d = m.depth(tok); m.roll(d); out += push_number(d) + bytes([OP_ROLL])
+        out += push_number(mval); m.push(('N', R))
+        out += bytes([OP_CHECKMULTISIG])
+        # CHECKMULTISIG pops: N-value + N pubkeys + M-value + M sigs + dummy
+        m.pop(2 * (t_total + 1) + 3); m.push(('cms', R))
+        return bytes(out), idxvals
+
+    def build_round_script(self, round_idx, sig_nonce_bytes):
+        """Build a single round's script IN ISOLATION (fresh stack, nothing below
+        its own witness). Used for size/opcode benchmarking. For a consensus-valid
+        two-round lock use build_full_script, which threads a shared model so
+        round 2's positions account for round 1's leftover."""
+        m = _StackModel()
+        self._seed_witness(m, round_idx)
+        script, _ = self._emit_round(m, round_idx, sig_nonce_bytes,
+                                     self._canonical_subset(round_idx))
         return script
-    
+
     def build_full_script(self, pin_sig, round1_sig, round2_sig):
-        """Build the complete locking script"""
-        script = self.build_pinning_script(pin_sig)
-        script += self.build_round_script(0, round1_sig)
-        script += self.build_round_script(1, round2_sig)
-        return script
-    
+        """Build the complete locking script with model-derived positions."""
+        m = _StackModel()
+        # full witness (bottom..top): round-2 block, round-1 block, pin key_puzzle, key_nonce
+        self._seed_witness(m, 1)
+        self._seed_witness(m, 0)
+        m.push(('pin_kp',)); m.push(('pin_kn',))
+        script = bytearray(self.build_pinning_script(pin_sig))
+        self._model_pinning(m)
+        s0, _ = self._emit_round(m, 0, round1_sig, self._canonical_subset(0))
+        s1, _ = self._emit_round(m, 1, round2_sig, self._canonical_subset(1))
+        return bytes(script) + s0 + s1
+
+    def compute_witness_indices(self, subsets):
+        """Given the chosen subsets {0:[...], 1:[...]}, return the witness index
+        numbers {0:[...], 1:[...]} the corrected selection loop expects (the
+        model-derived dummy depths). Replays the same model build_full_script uses."""
+        m = _StackModel()
+        self._seed_witness(m, 1)
+        self._seed_witness(m, 0)
+        m.push(('pin_kp',)); m.push(('pin_kn',))
+        self._model_pinning(m)
+        _, iv0 = self._emit_round(m, 0, b'\x30\x06\x02\x01\x01\x02\x01\x01\x01', subsets[0])
+        _, iv1 = self._emit_round(m, 1, b'\x30\x06\x02\x01\x01\x02\x01\x01\x01', subsets[1])
+        return {0: iv0, 1: iv1}
+
     @staticmethod
     def count_opcodes(script):
         """Count non-push opcodes (>= 0x60) in a script, matching Bitcoin Core's rule.
@@ -543,37 +599,37 @@ class QSBScriptBuilder:
 
 if __name__ == "__main__":
     print("=== Transaction test ===")
-    
+
     # Create a simple transaction
     tx = Transaction(version=1, locktime=0)
     tx.add_input(TxIn(b'\x00' * 32, 0, b'', 0xffffffff))
     tx.add_output(TxOut(50000, b'\x76\xa9' + b'\x14' + b'\x00' * 20 + b'\x88\xac'))
-    
+
     serialized = tx.serialize()
     print(f"Tx serialized: {len(serialized)} bytes")
-    
+
     # Test sighash
     z = tx.sighash(0, b'\x00' * 25, sighash_type=0x01)
     print(f"Sighash: {z:#066x}")
-    
+
     # Test script builder
     print("\n=== Script builder test (small n=5, t=2) ===")
     builder = QSBScriptBuilder(n=5, t1_signed=2, t2_signed=2)
     builder.generate_keys()
-    
+
     # Create dummy sig_nonce
     pin_sig = encode_der_sig(123456789, 987654321, sighash=0x01)
     r1_sig = encode_der_sig(111111111, 222222222, sighash=0x01)
     r2_sig = encode_der_sig(333333333, 444444444, sighash=0x01)
-    
+
     full_script = builder.build_full_script(pin_sig, r1_sig, r2_sig)
     print(f"Full script: {len(full_script)} bytes")
-    
+
     # Test FindAndDelete
     print("\n=== FindAndDelete test ===")
     test_script = push_data(b'\xaa\xbb') + push_data(b'\xcc\xdd') + push_data(b'\xaa\xbb')
     deleted = find_and_delete(test_script, b'\xaa\xbb')
     assert deleted == push_data(b'\xcc\xdd'), "FindAndDelete failed"
     print("[OK] FindAndDelete")
-    
+
     print("\n[ALL OK]")

--- a/pipeline/qsb_pipeline.py
+++ b/pipeline/qsb_pipeline.py
@@ -588,7 +588,15 @@ def cmd_assemble(args):
     assert len(r2_indices) == t2, f"Expected {t2} round2 indices, got {len(r2_indices)}"
     
     full_script = h2b(state['full_script_hex'])
-    
+
+    # Corrected witness index encoding: the selection loop reads model-derived
+    # dummy-depths, not raw pool indices. Rebuild a builder holding the pool data
+    # and compute the indices exactly as build_full_script positioned them.
+    _wb = QSBScriptBuilder(n, state['t1s'], state['t1b'], state['t2s'], state['t2b'])
+    _wb.hors_commitments = [[h2b(c) for c in state['hors_commitments'][r]] for r in range(2)]
+    _wb.dummy_sigs = [[h2b(s) for s in state['dummy_sigs'][r]] for r in range(2)]
+    witness_indices = _wb.compute_witness_indices({0: r1_indices, 1: r2_indices})
+
     print(f"  Locktime: {locktime}")
     print(f"  Sequence: {sequence} (0x{sequence:08X})")
     print(f"  Round 1 indices: {r1_indices}")
@@ -719,8 +727,12 @@ def cmd_assemble(args):
         if key_puzzle_round is None:
             print(f"    ERROR: round {ri+1} key_puzzle recovery failed!")
             return
-        
-        # Recover dummy pubkeys (z=1)
+
+        # Recover dummy pubkeys via the SIGHASH_SINGLE bug. Bitcoin Core's bug
+        # value is 2**248 (uint256::ONE's little-endian bytes read big-endian by
+        # secp256k1), NOT the integer 1 — must match or the dummies fail consensus.
+        # This requires QSB_INPUT_INDEX >= num_outputs
+        SIGHASH_SINGLE_BUG_Z = 1 << 248
         dummy_pubkeys = []
         for idx in indices:
             ds_bytes = h2b(state['dummy_sigs'][ri][idx])
@@ -729,7 +741,7 @@ def cmd_assemble(args):
                 print(f"    ERROR: dummy sig {idx} not valid DER!")
                 return
             for flag in [0, 1]:
-                pt = ecdsa_recover(dr, ds_val, 1, flag)
+                pt = ecdsa_recover(dr, ds_val, SIGHASH_SINGLE_BUG_Z, flag)
                 if pt:
                     dummy_pubkeys.append(compress_pubkey(pt))
                     break
@@ -761,8 +773,11 @@ def cmd_assemble(args):
             witness += push_data(pub)
         for pre in reversed(rr['preimages']):
             witness += push_data(pre)
-        for idx in reversed(rr['subset']):
-            witness += push_number(idx)
+        # model-derived index numbers (NOT raw pool indices); pushed so that
+        # selection 0's index ends on top, matching _seed_witness order.
+        ivs = witness_indices[rd]
+        for j in range(len(ivs) - 1, -1, -1):
+            witness += push_number(ivs[j])
     
     witness += push_data(key_puzzle_pin)
     witness += push_data(key_nonce_pin)

--- a/pipeline/test_bitcoinconsensus.py
+++ b/pipeline/test_bitcoinconsensus.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""
+Gold-standard gate: run the CORRECTED lock through REAL Bitcoin Core consensus
+code (libbitcoinconsensus, via ../../QSB/qsb_verify). Confirms our legacy
+sighash == Core's — the one thing our own interpreter can't self-certify, and
+the exact gap that could silently burn funding + GPU money.
+
+Puzzle relaxed (each puzzle CHECKSIGVERIFY -> OP_2DROP, identical opcode count &
+stack effect); pinning-bind + both CHECKMULTISIGs stay REAL. Emits funding+
+spending tx hex and invokes qsb_verify on the QSB input.
+"""
+import sys, struct, hashlib, subprocess, tempfile, os
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+# ── pure-python RIPEMD160 (OpenSSL3) ──
+def _rol(x,n): return ((x<<n)|(x>>(32-n)))&0xFFFFFFFF
+_K1=(0,0x5A827999,0x6ED9EBA1,0x8F1BBCDC,0xA953FD4E);_K2=(0x50A28BE6,0x5C4DD124,0x6D703EF3,0x7A6D76E9,0)
+_R1=[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,7,4,13,1,10,6,15,3,12,0,9,5,2,14,11,8,3,10,14,4,9,15,8,1,2,7,0,6,13,11,5,12,1,9,11,10,0,8,12,4,13,3,7,15,14,5,6,2,4,0,5,9,7,12,2,10,14,1,3,8,11,6,15,13]
+_R2=[5,14,7,0,9,2,11,4,13,6,15,8,1,10,3,12,6,11,3,7,0,13,5,10,14,15,8,12,4,9,1,2,15,5,1,3,7,14,6,9,11,8,12,2,10,0,4,13,8,6,4,1,3,11,15,0,5,12,2,13,9,7,10,14,12,15,10,4,1,5,8,7,6,2,13,14,0,3,9,11]
+_S1=[11,14,15,12,5,8,7,9,11,13,14,15,6,7,9,8,7,6,8,13,11,9,7,15,7,12,15,9,11,7,13,12,11,13,6,7,14,9,13,15,14,8,13,6,5,12,7,5,11,12,14,15,14,15,9,8,9,14,5,6,8,6,5,12,9,15,5,11,6,8,13,12,5,12,13,14,11,8,5,6]
+_S2=[8,9,9,11,13,15,15,5,7,7,8,11,14,14,12,6,9,13,15,7,12,8,9,11,7,7,12,7,6,15,13,11,9,7,15,11,8,6,6,14,12,13,5,14,13,13,7,5,15,5,8,11,14,14,6,14,6,9,12,9,12,5,15,8,8,5,12,9,12,5,14,6,8,13,6,5,15,13,11,11]
+def _f(j,x,y,z):
+    if j<16:return x^y^z
+    if j<32:return (x&y)|(~x&z)
+    if j<48:return (x|~y)^z
+    if j<64:return (x&z)|(y&~z)
+    return x^(y|~z)
+def ripemd160(data):
+    h=[0x67452301,0xEFCDAB89,0x98BADCFE,0x10325476,0xC3D2E1F0];msg=bytearray(data);ml=len(data)*8;msg.append(0x80)
+    while len(msg)%64!=56:msg.append(0)
+    msg+=struct.pack('<Q',ml)
+    for off in range(0,len(msg),64):
+        X=struct.unpack_from('<16I',msg,off);a,b,c,d,e=h;A,B,C,D,E=h
+        for j in range(80):
+            T=(a+_f(j,b,c,d)+X[_R1[j]]+_K1[j//16])&0xFFFFFFFF;T=(_rol(T,_S1[j])+e)&0xFFFFFFFF;a,e,d,c,b=e,d,_rol(c,10),b,T
+            T=(A+_f(79-j,B,C,D)+X[_R2[j]]+_K2[j//16])&0xFFFFFFFF;T=(_rol(T,_S2[j])+E)&0xFFFFFFFF;A,E,D,C,B=E,D,_rol(C,10),B,T
+        T=(h[1]+c+D)&0xFFFFFFFF;h[1]=(h[2]+d+E)&0xFFFFFFFF;h[2]=(h[3]+e+A)&0xFFFFFFFF;h[3]=(h[4]+a+B)&0xFFFFFFFF;h[4]=(h[0]+b+C)&0xFFFFFFFF;h[0]=T
+    return struct.pack('<5I',*h)
+
+import secp256k1 as S
+S.ripemd160=ripemd160; S.hash160=lambda d: ripemd160(hashlib.sha256(d).digest())
+import bitcoin_tx as bt
+bt.ripemd160=ripemd160; bt.hash160=S.hash160
+from bitcoin_tx import (QSBScriptBuilder, Transaction, TxIn, TxOut,
+                        find_and_delete, push_data, push_number, serialize_varint, _valid_small_r_values)
+from secp256k1 import N, P, ecdsa_recover, ecdsa_verify, compress_pubkey, encode_der_sig
+
+def parse_der(sig):
+    if len(sig)<9 or sig[0]!=0x30: return None
+    if sig[1]+3!=len(sig): return None
+    i=2
+    if sig[i]!=0x02: return None
+    i+=1; rl=sig[i]; i+=1
+    if rl==0 or i+rl>len(sig)-1 or sig[i]&0x80: return None
+    if rl>1 and sig[i]==0 and not (sig[i+1]&0x80): return None
+    r=int.from_bytes(sig[i:i+rl],'big'); i+=rl
+    if sig[i]!=0x02: return None
+    i+=1; sl=sig[i]; i+=1
+    if sl==0 or i+sl!=len(sig)-1: return None
+    return (r, int.from_bytes(sig[i:i+sl],'big'), sig[-1])
+def recover_key(r,s,z):
+    for rr in ([r]+([r+N] if r+N<P else [])):
+        for rec in (0,1):
+            pt=ecdsa_recover(rr,s,z,rec)
+            if pt and ecdsa_verify(pt,z,r,s): return compress_pubkey(pt)
+    return None
+
+# ── build corrected lock (valid on-curve anchors) ──
+b=QSBScriptBuilder(150,8,1,7,2); b.generate_keys()
+vr=_valid_small_r_values()[0]
+pin_sig=encode_der_sig(vr,1,0x01); sig_nonce=[encode_der_sig(vr,2,0x01), encode_der_sig(vr,3,0x01)]
+lock=b.build_full_script(pin_sig, sig_nonce[0], sig_nonce[1])
+
+# ── relax puzzle: keep 1st CHECKSIGVERIFY (pinning bind), turn the other 3 into OP_2DROP ──
+def relax(script):
+    out=bytearray(script); i=0; seen=0
+    while i<len(out):
+        op=out[i]
+        if op==0: i+=1
+        elif 1<=op<=75: i+=1+op
+        elif op==0x4c: i+=2+out[i+1]
+        elif op==0x4d: i+=3+(out[i+1]|out[i+2]<<8)
+        else:
+            if op==0xad:                       # OP_CHECKSIGVERIFY
+                seen+=1
+                if seen>=2: out[i]=0x6d          # OP_2DROP (relax the 3 puzzle checks)
+            i+=1
+    return bytes(out)
+lock_relaxed=relax(lock)
+print(f"lock: {len(lock)} bytes; relaxed 3 puzzle checks -> same length {len(lock_relaxed)}")
+
+# ── spending tx (QSB @ input 1), arbitrary subsets (puzzle relaxed) ──
+QSB=1
+tx=Transaction(version=1, locktime=1234567)
+tx.add_input(TxIn(b'\x00'*32,0,b'',0xfffffffe))
+tx.add_input(TxIn(b'\x11'*32,0,b'',0x80000000))
+tx.add_output(TxOut(90000, bytes([0x00,0x14])+b'\x22'*20))
+subs={0:sorted([3,17,42,66,88,101,119,140])+[9], 1:sorted([5,20,55,70,90,110,130])+[15,45]}
+iv=b.compute_witness_indices(subs)
+
+def round_keys(R):
+    sc=find_and_delete(lock_relaxed, sig_nonce[R])
+    for i in subs[R]: sc=find_and_delete(sc, b.dummy_sigs[R][i])
+    z=tx.sighash(QSB, sc, 0x01)
+    pr,ps,_=parse_der(sig_nonce[R]); kn=recover_key(pr,ps,z)
+    dp=[recover_key(*parse_der(b.dummy_sigs[R][i])[:2],1<<248) for i in subs[R]]
+    return kn,dp
+
+wit=b''
+for R in (1,0):
+    ts=b.t1_signed if R==0 else b.t2_signed
+    kn,dp=round_keys(R); assert kn and all(dp), f"recover round {R}"
+    wit+=push_data(b'\x02'+b'\x00'*32)+push_data(kn)
+    for p in reversed(dp): wit+=push_data(p)
+    for j in range(ts-1,-1,-1): wit+=push_data(b.hors_secrets[R][subs[R][j]])
+    for j in range(len(iv[R])-1,-1,-1): wit+=push_number(iv[R][j])
+psc=find_and_delete(lock_relaxed, pin_sig); zp=tx.sighash(QSB,psc,0x01)
+ppr,pps,_=parse_der(pin_sig); knp=recover_key(ppr,pps,zp); assert knp,"pin recover"
+wit+=push_data(b'\x02'+b'\x00'*32)+push_data(knp)
+tx.inputs[QSB].script_sig=wit
+
+# ── funding tx: vout 0 = relaxed lock ──
+ftx=Transaction(version=1, locktime=0)
+ftx.add_input(TxIn(b'\x33'*32,0,b'',0xffffffff))
+ftx.add_output(TxOut(100000, lock_relaxed))
+
+QV="/home/tomer/workspace/QSB/qsb_verify/target/release/qsb_verify"
+def core_check(lockspk, witness_ss, label):
+    ft=Transaction(1,0); ft.add_input(TxIn(b'\x33'*32,0,b'',0xffffffff)); ft.add_output(TxOut(100000,lockspk))
+    st=Transaction(1,1234567); st.add_input(TxIn(b'\x00'*32,0,b'',0xfffffffe))
+    st.add_input(TxIn(b'\x11'*32,0,witness_ss,0x80000000)); st.add_output(TxOut(90000, bytes([0x00,0x14])+b'\x22'*20))
+    dd=tempfile.mkdtemp(); s=os.path.join(dd,'s'); f=os.path.join(dd,'f')
+    open(s,'w').write(st.serialize().hex()); open(f,'w').write(ft.serialize().hex())
+    r=subprocess.run([QV,s,f,"0","1"],capture_output=True,text=True)
+    ok = "✅ SUCCESS" in r.stdout
+    line=[l for l in r.stdout.splitlines() if "NONE" in l]
+    print(f"  [{label}] Core VERIFY_NONE: {'✅ SUCCESS' if ok else '❌ '+(line[0].split('...')[-1].strip() if line else 'ERR')}")
+    return ok
+
+# --- DIAGNOSTIC 1: my own interpreter on the SAME relaxed lock ---
+def di(x):
+    if not x: return 0
+    v=int.from_bytes(x,'little')
+    if x[-1]&0x80: v&=(1<<(8*len(x)))-1-(0x80<<(8*(len(x)-1))); v=-v
+    return v
+def ei(v):
+    if v==0: return b''
+    o=bytearray(); y=abs(v)
+    while y: o.append(y&0xff); y>>=8
+    if o[-1]&0x80: o.append(0)
+    return bytes(o)
+def toks(sc):
+    i=0
+    while i<len(sc):
+        op=sc[i]
+        if op==0: yield('p',b''); i+=1
+        elif 1<=op<=75: yield('p',sc[i+1:i+1+op]); i+=1+op
+        elif op==0x4c: k=sc[i+1]; yield('p',sc[i+2:i+2+k]); i+=2+k
+        elif op==0x4d: k=sc[i+1]|sc[i+2]<<8; yield('p',sc[i+3:i+3+k]); i+=3+k
+        elif 0x51<=op<=0x60: yield('p',bytes([op-0x50])); i+=1
+        else: yield('o',op); i+=1
+from secp256k1 import decompress_pubkey
+def csig(sig,pub,allcs):
+    p=parse_der(sig)
+    if not p: return True
+    r,s,fl=p; sc=lock_relaxed
+    for cs in allcs: sc=find_and_delete(sc,cs)
+    z=tx.sighash(QSB,sc,fl)
+    try: return ecdsa_verify(decompress_pubkey(pub),z,r,s)
+    except Exception: return False
+st=[v for k,v in toks(wit)]; hp=cms=0; peak=len(st); fail=None
+for k,v in toks(lock_relaxed):
+    if k=='p': st.append(v); peak=max(peak,len(st)); continue
+    op=v
+    if op==0x7a: nn=di(st.pop()); st.append(st.pop(-1-nn))
+    elif op==0x76: st.append(st[-1])
+    elif op==0x78: st.append(st[-2])
+    elif op==0x7c: st[-1],st[-2]=st[-2],st[-1]
+    elif op==0x6d: st.pop(); st.pop()             # OP_2DROP (relaxed puzzle)
+    elif op==0x93: y=di(st.pop());x=di(st.pop());st.append(ei(x+y))
+    elif op==0xa3: y=di(st.pop());x=di(st.pop());st.append(ei(min(x,y)))
+    elif op==0xa9: st.append(ripemd160(hashlib.sha256(st.pop()).digest()))
+    elif op==0xa8: st.append(hashlib.sha256(st.pop()).digest())
+    elif op==0xa6: st.append(ripemd160(st.pop()))
+    elif op==0x88:
+        a=st.pop();c=st.pop()
+        if a==c: hp+=1
+        elif fail is None: fail=('HORS',)
+    elif op==0xad:
+        pub=st.pop();sig=st.pop()
+        if not csig(sig,pub,[sig]) and fail is None: fail=('CHECKSIG',)
+    elif op==0xae:
+        nk=di(st.pop()); pubs=[st.pop() for _ in range(nk)][::-1]
+        ns=di(st.pop()); sigs=[st.pop() for _ in range(ns)][::-1]; st.pop()
+        allcs=[x for x in sigs if parse_der(x)]; si=0; mt=0
+        for sg in sigs:
+            while si<nk:
+                if csig(sg,pubs[si],allcs): mt+=1; si+=1; break
+                si+=1
+            else: break
+        st.append(b'\x01' if mt==ns else b''); cms+=1
+        if mt!=ns and fail is None: fail=('CMS',mt,ns)
+    peak=max(peak,len(st))
+truthy=bool(st) and any(x!=0 for x in st[-1])
+print(f"  [mine] HORS {hp}/15  CMS {cms}/2  peak_stack {peak}  TRUE={truthy}  fail={fail}")
+
+# --- DIAGNOSTIC 2: pinning-ONLY relaxed lock through Core (isolates sighash) ---
+pin_only = relax(bytes(bt.QSBScriptBuilder.build_pinning_script(b, pin_sig)))
+pin_wit = push_data(b'\x02'+b'\x00'*32) + push_data(knp)
+core_check(pin_only, pin_wit, "pinning-only")
+
+# --- full relaxed lock through Core ---
+print("\nrunning qsb_verify (real libbitcoinconsensus) on the FULL QSB input...\n")
+d=tempfile.mkdtemp()
+sp=os.path.join(d,'spend.hex'); fp=os.path.join(d,'fund.hex')
+open(sp,'w').write(tx.serialize().hex()); open(fp,'w').write(ftx.serialize().hex())
+r=subprocess.run([QV, sp, fp, "0", "1"], capture_output=True, text=True)
+print(r.stdout[-800:] if r.stdout else r.stderr[-800:])

--- a/pipeline/test_consensus_cpu.py
+++ b/pipeline/test_consensus_cpu.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""
+test_consensus_cpu.py — the pre-GPU gate.
+
+Builds the CORRECTED lock (real keys), assembles a spending tx + witness with
+REAL recovered keys / real HORS preimages / model-derived indices, and runs the
+QSB input through a faithful LEGACY interpreter that does REAL ECDSA on every
+signature — EXCEPT the unsolved hash-to-DER puzzle, which is relaxed (a puzzle
+sig is a fresh hash, i.e. not valid DER; in production the ~2^46 search makes it
+valid DER, here we skip only that one gate).
+
+What this proves that the earlier structural test could NOT:
+  • pinning: sig_nonce really verifies against the recovered key_nonce
+  • rounds : the 9 dummy sigs (z=1) AND sig_nonce really verify inside
+             CHECKMULTISIG, in the exact pubkey/sig ORDER the fix produces
+  • HORS  : real HASH160(preimage) == commitment
+  • the whole script ends TRUE under real crypto
+
+Relaxed = only the puzzle DER-validity (unchanged by the fix, already proven on
+chain via pinning). Run on CPU in well under a second.
+"""
+import sys, os, struct, hashlib
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+# ── pure-python RIPEMD160 (OpenSSL 3 dropped it) ──
+def _rol(x,n): return ((x<<n)|(x>>(32-n)))&0xFFFFFFFF
+_K1=(0,0x5A827999,0x6ED9EBA1,0x8F1BBCDC,0xA953FD4E); _K2=(0x50A28BE6,0x5C4DD124,0x6D703EF3,0x7A6D76E9,0)
+_R1=[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,7,4,13,1,10,6,15,3,12,0,9,5,2,14,11,8,3,10,14,4,9,15,8,1,2,7,0,6,13,11,5,12,1,9,11,10,0,8,12,4,13,3,7,15,14,5,6,2,4,0,5,9,7,12,2,10,14,1,3,8,11,6,15,13]
+_R2=[5,14,7,0,9,2,11,4,13,6,15,8,1,10,3,12,6,11,3,7,0,13,5,10,14,15,8,12,4,9,1,2,15,5,1,3,7,14,6,9,11,8,12,2,10,0,4,13,8,6,4,1,3,11,15,0,5,12,2,13,9,7,10,14,12,15,10,4,1,5,8,7,6,2,13,14,0,3,9,11]
+_S1=[11,14,15,12,5,8,7,9,11,13,14,15,6,7,9,8,7,6,8,13,11,9,7,15,7,12,15,9,11,7,13,12,11,13,6,7,14,9,13,15,14,8,13,6,5,12,7,5,11,12,14,15,14,15,9,8,9,14,5,6,8,6,5,12,9,15,5,11,6,8,13,12,5,12,13,14,11,8,5,6]
+_S2=[8,9,9,11,13,15,15,5,7,7,8,11,14,14,12,6,9,13,15,7,12,8,9,11,7,7,12,7,6,15,13,11,9,7,15,11,8,6,6,14,12,13,5,14,13,13,7,5,15,5,8,11,14,14,6,14,6,9,12,9,12,5,15,8,8,5,12,9,12,5,14,6,8,13,6,5,15,13,11,11]
+def _f(j,x,y,z):
+    if j<16: return x^y^z
+    if j<32: return (x&y)|(~x&z)
+    if j<48: return (x|~y)^z
+    if j<64: return (x&z)|(y&~z)
+    return x^(y|~z)
+def ripemd160(data):
+    h=[0x67452301,0xEFCDAB89,0x98BADCFE,0x10325476,0xC3D2E1F0]
+    msg=bytearray(data); ml=len(data)*8; msg.append(0x80)
+    while len(msg)%64!=56: msg.append(0)
+    msg+=struct.pack('<Q',ml)
+    for off in range(0,len(msg),64):
+        X=struct.unpack_from('<16I',msg,off); a,b,c,d,e=h; A,B,C,D,E=h
+        for j in range(80):
+            T=(a+_f(j,b,c,d)+X[_R1[j]]+_K1[j//16])&0xFFFFFFFF; T=(_rol(T,_S1[j])+e)&0xFFFFFFFF
+            a,e,d,c,b=e,d,_rol(c,10),b,T
+            T=(A+_f(79-j,B,C,D)+X[_R2[j]]+_K2[j//16])&0xFFFFFFFF; T=(_rol(T,_S2[j])+E)&0xFFFFFFFF
+            A,E,D,C,B=E,D,_rol(C,10),B,T
+        T=(h[1]+c+D)&0xFFFFFFFF; h[1]=(h[2]+d+E)&0xFFFFFFFF; h[2]=(h[3]+e+A)&0xFFFFFFFF
+        h[3]=(h[4]+a+B)&0xFFFFFFFF; h[4]=(h[0]+b+C)&0xFFFFFFFF; h[0]=T
+    return struct.pack('<5I',*h)
+assert ripemd160(b'abc').hex()=='8eb208f7e05d987a9b044a8e98c6b087f15a0bfc'
+
+import secp256k1 as S
+S.ripemd160 = ripemd160
+S.hash160   = lambda d: ripemd160(hashlib.sha256(d).digest())
+import bitcoin_tx as bt
+bt.ripemd160 = ripemd160; bt.hash160 = S.hash160
+from bitcoin_tx import (QSBScriptBuilder, Transaction, TxIn, TxOut,
+                        find_and_delete, push_data, push_number)
+from secp256k1 import (N, P, ecdsa_recover, ecdsa_verify, decompress_pubkey,
+                       compress_pubkey, encode_der_sig)
+
+def h160(x): return ripemd160(hashlib.sha256(x).digest())
+
+def parse_der(sig):
+    """Return (r,s,flag) if `sig` is valid DER (+trailing flag byte), else None."""
+    if len(sig) < 9 or sig[0] != 0x30: return None
+    tl = sig[1]
+    if tl + 3 != len(sig): return None
+    idx = 2
+    if sig[idx] != 0x02: return None
+    idx += 1; rl = sig[idx]; idx += 1
+    if rl == 0 or idx+rl > len(sig)-1: return None
+    if rl > 1 and sig[idx] == 0 and not (sig[idx+1] & 0x80): return None
+    if sig[idx] & 0x80: return None
+    r = int.from_bytes(sig[idx:idx+rl], 'big'); idx += rl
+    if sig[idx] != 0x02: return None
+    idx += 1; sl = sig[idx]; idx += 1
+    if sl == 0 or idx+sl != len(sig)-1: return None
+    s = int.from_bytes(sig[idx:idx+sl], 'big')
+    return (r, s, sig[-1])
+
+def recover_key(r, s, z):
+    """Recover a pubkey that verifies (r,s) over z (try both recids / r,r+N)."""
+    for rr in ([r] + ([r+N] if r+N < P else [])):
+        for recid in (0, 1):
+            pt = ecdsa_recover(rr, s, z, recid)
+            if pt and ecdsa_verify(pt, z, r, s):
+                return compress_pubkey(pt)
+    return None
+
+# ══════════════════════════════════════════════════════════════════
+# 1. Build the corrected lock (Config A) with real keys
+# ══════════════════════════════════════════════════════════════════
+b = QSBScriptBuilder(150, 8, 1, 7, 2)
+b.generate_keys()
+# distinct SIGHASH_ALL anchors; r MUST be a valid on-curve x-coordinate so
+# key recovery works. Same r, distinct s → 3 distinct minimal 9-byte sigs;
+# flag 0x01 keeps them distinct from the dummies (flag 0x03).
+from bitcoin_tx import _valid_small_r_values
+vr = _valid_small_r_values()[0]
+pin_sig      = encode_der_sig(vr, 1, 0x01)
+sig_nonce    = [encode_der_sig(vr, 2, 0x01), encode_der_sig(vr, 3, 0x01)]
+lock = b.build_full_script(pin_sig, sig_nonce[0], sig_nonce[1])
+print(f"lock: {len(lock)} bytes")
+
+# ══════════════════════════════════════════════════════════════════
+# 2. Spending tx (2 inputs, 1 output).  QSB at input 1.  Arbitrary
+#    locktime/sequence/subsets — no search needed (puzzle relaxed).
+# ══════════════════════════════════════════════════════════════════
+QSB = 1
+tx = Transaction(version=1, locktime=1234567)
+tx.add_input(TxIn(b'\x00'*32, 0, b'', 0xfffffffe))            # helper (input 0)
+tx.add_input(TxIn(b'\x11'*32, 0, b'', 0x80000000))            # QSB    (input 1)
+tx.add_output(TxOut(90000, bytes([0x00,0x14])+b'\x22'*20))     # 1 output (SIGHASH_SINGLE bug at input 1)
+subs = {0: sorted([3,17,42,66,88,101,119,140])+[9],
+        1: sorted([5,20,55,70,90,110,130])+[15,45]}
+idxvals = b.compute_witness_indices(subs)
+
+# ══════════════════════════════════════════════════════════════════
+# 3. Assemble the witness with REAL recovered keys / preimages
+# ══════════════════════════════════════════════════════════════════
+def recover_round_keys(R):
+    sc = find_and_delete(lock, sig_nonce[R])
+    for i in subs[R]:
+        sc = find_and_delete(sc, b.dummy_sigs[R][i])
+    z = tx.sighash(QSB, sc, 0x01)
+    pr, ps, _ = parse_der(sig_nonce[R])
+    key_nonce = recover_key(pr, ps, z)
+    dummy_pub = []
+    for i in subs[R]:
+        dr, ds, _ = parse_der(b.dummy_sigs[R][i])
+        dummy_pub.append(recover_key(dr, ds, 1 << 248))  # z=2**248 (corrected SIGHASH_SINGLE bug)
+    return key_nonce, dummy_pub
+
+witness = b''
+for R in (1, 0):
+    ts = b.t1_signed if R == 0 else b.t2_signed
+    key_nonce, dummy_pub = recover_round_keys(R)
+    assert key_nonce and all(dummy_pub), f"recovery failed round {R}"
+    witness += push_data(b'\x02'+b'\x00'*32)          # key_puzzle (relaxed → unused)
+    witness += push_data(key_nonce)                    # key_nonce (REAL)
+    for pub in reversed(dummy_pub): witness += push_data(pub)
+    for j in range(ts-1, -1, -1): witness += push_data(b.hors_secrets[R][subs[R][j]])
+    for j in range(len(idxvals[R])-1, -1, -1): witness += push_number(idxvals[R][j])
+# pinning
+pin_sc = find_and_delete(lock, pin_sig)
+z_pin = tx.sighash(QSB, pin_sc, 0x01)
+ppr, pps, _ = parse_der(pin_sig)
+key_nonce_pin = recover_key(ppr, pps, z_pin)
+assert key_nonce_pin, "pinning recovery failed"
+witness += push_data(b'\x02'+b'\x00'*32)               # key_puzzle_pin (relaxed)
+witness += push_data(key_nonce_pin)
+
+# ══════════════════════════════════════════════════════════════════
+# 4. Interpret with REAL ECDSA (relax only the unsolved puzzle)
+# ══════════════════════════════════════════════════════════════════
+def toks(sc):
+    i=0
+    while i<len(sc):
+        op=sc[i]
+        if op==0: yield('p',b''); i+=1
+        elif 1<=op<=75: yield('p',sc[i+1:i+1+op]); i+=1+op
+        elif op==0x4c: k=sc[i+1]; yield('p',sc[i+2:i+2+k]); i+=2+k
+        elif op==0x4d: k=sc[i+1]|sc[i+2]<<8; yield('p',sc[i+3:i+3+k]); i+=3+k
+        elif 0x51<=op<=0x60: yield('p',bytes([op-0x50])); i+=1
+        else: yield('o',op); i+=1
+def di(x):
+    if not x: return 0
+    v=int.from_bytes(x,'little')
+    if x[-1]&0x80: v&=(1<<(8*len(x)))-1-(0x80<<(8*(len(x)-1))); v=-v
+    return v
+def ei(v):
+    if v==0: return b''
+    o=bytearray(); y=abs(v)
+    while y: o.append(y&0xff); y>>=8
+    if o[-1]&0x80: o.append(0)
+    return bytes(o)
+
+def checksig_real(sig, pubkey, all_check_sigs):
+    """REAL ecdsa verify over the legacy sighash. Relax if sig isn't valid DER
+    (an unsolved puzzle sig) — that's the only relaxation."""
+    p = parse_der(sig)
+    if p is None:
+        return ('relaxed', True)          # unsolved hash-to-DER puzzle → skip only this
+    r, s, flag = p
+    sc = lock
+    for cs in all_check_sigs: sc = find_and_delete(sc, cs)
+    z = tx.sighash(QSB, sc, flag)          # z=1 automatically for SIGHASH_SINGLE @ input1
+    try: pt = decompress_pubkey(pubkey)
+    except Exception: return ('real', False)
+    return ('real', ecdsa_verify(pt, z, r, s))
+
+st = [v for k,v in toks(witness)]
+hors=0; cms=0; real_sig=0; relaxed=0; fail=None
+for k,v in toks(lock):
+    if k=='p': st.append(v); continue
+    op=v
+    try:
+        if op==0x7a: nn=di(st.pop()); st.append(st.pop(-1-nn))
+        elif op==0x76: st.append(st[-1])
+        elif op==0x78: st.append(st[-2])
+        elif op==0x7c: st[-1],st[-2]=st[-2],st[-1]
+        elif op==0x93: y=di(st.pop());x=di(st.pop());st.append(ei(x+y))
+        elif op==0xa3: y=di(st.pop());x=di(st.pop());st.append(ei(min(x,y)))
+        elif op==0xa9: st.append(h160(st.pop()))
+        elif op==0xa8: st.append(hashlib.sha256(st.pop()).digest())
+        elif op==0xa6: st.append(ripemd160(st.pop()))
+        elif op==0x88:                                   # OP_EQUALVERIFY = HORS
+            a=st.pop(); c=st.pop()
+            if a==c: hors+=1
+            elif fail is None: fail=('HORS',a.hex()[:12],c.hex()[:12])
+        elif op==0xad:                                   # OP_CHECKSIGVERIFY
+            pub=st.pop(); sig=st.pop()
+            kind,ok=checksig_real(sig, pub, [sig])
+            if kind=='real': real_sig+=1
+            else: relaxed+=1
+            if not ok and fail is None: fail=('CHECKSIG',sig.hex()[:16],pub.hex()[:12])
+        elif op==0xae:                                   # OP_CHECKMULTISIG (REAL, ordered)
+            nk=di(st.pop()); pubs=[st.pop() for _ in range(nk)][::-1]
+            ns=di(st.pop()); sigs=[st.pop() for _ in range(ns)][::-1]
+            st.pop()                                      # the OP_0 dummy
+            allcs=[s for s in sigs if parse_der(s)]       # F&D all real sigs in this CMS
+            si=0; matched=0
+            for sig in sigs:
+                while si<nk:
+                    kind,ok=checksig_real(sig, pubs[si], allcs)
+                    if ok: matched+=1; si+=1; break
+                    si+=1
+                else: break
+                if kind=='real': real_sig+=1
+                else: relaxed+=1
+            good = (matched==ns)
+            st.append(b'\x01' if good else b''); cms+=1
+            if not good and fail is None: fail=('CMS', f'{matched}/{ns}', '')
+    except Exception as e:
+        fail=('crash',str(e),''); break
+
+top = st[-1] if st else b''
+truthy = any(x!=0 for x in top)
+exp_hors = b.t1_signed + b.t2_signed
+print(f"HORS: {hors}/{exp_hors}   CHECKMULTISIGs: {cms}/2   real ECDSA checks: {real_sig}   relaxed(puzzle): {relaxed}")
+print(f"final stack TRUE: {truthy}")
+if fail: print("FAIL:", fail)
+ok = (hors==exp_hors and cms==2 and truthy and fail is None)
+print("\nCPU CONSENSUS TEST: " + ("PASS ✅  (real signatures verify; only the puzzle was relaxed)" if ok
+                                  else "FAIL ❌"))
+sys.exit(0 if ok else 1)


### PR DESCRIPTION
## Summary

Fixes an off-by-one in the round-script stack positions that produced an **unspendable** QSB lock, plus a wrong SIGHASH_SINGLE bug value. Verified consensus-valid against real Bitcoin Core.

### 1. Off-by-one in OP_ROLL positions
`build_round_script` used hand-derived stack-position formulas that were off by one — they omitted the `OP_0` CHECKMULTISIG dummy in the count and used a fixed commitment gap (`n+1`) that must actually shrink to `n+1-i` per iteration, and they ignored cross-round drift (round 2 sits one item higher than round 1 because round 1 leaves a CHECKMULTISIG result on the stack). This is replaced with a live `_StackModel` that computes every `OP_ROLL` depth from the actual modeled stack, making positions correct by construction. `compute_witness_indices` replays the same model so the witness index numbers match.

### 2. SIGHASH_SINGLE bug value (`1` -> `2**248`)
Bitcoin Core returns `uint256::ONE`, whose little-endian bytes `01 00..00` are read big-endian by secp256k1's msg32 — i.e. the message scalar is `2**248`, not the integer `1`. `sighash()` now returns `1 << 248`, and dummy-pubkey recovery in `cmd_assemble` uses the same value.

## Verification
Two consensus gates added:
- **`test_consensus_cpu.py`** — pure-Python legacy interpreter with real ECDSA on every signature (only the unsolved hash-to-DER puzzle relaxed). Fast, no external deps, per-opcode failure detail. Result: HORS 15/15, both CHECKMULTISIGs pass, final stack TRUE.
- **`test_bitcoinconsensus.py`** — runs the corrected lock through **real `libbitcoinconsensus`** via `qsb_verify`. Result: ✅ SUCCESS under every flag set including `ALL_PRE_TAPROOT`.

Both are needed: the CPU test can't self-certify the sighash (shared authorship with the interpreter), while Core is the independent oracle but only reports pass/fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)